### PR TITLE
When the polygon is changed, it is not emptied （this._rectShape）

### DIFF
--- a/src/Path.Transform.js
+++ b/src/Path.Transform.js
@@ -125,6 +125,7 @@ L.Handler.PathTransform = L.Handler.extend({
     this._rect           = null;
     this._handlers       = [];
     this._handleLine     = null;
+     this._rectShape = null;
   },
 
 
@@ -166,6 +167,7 @@ L.Handler.PathTransform = L.Handler.extend({
     this._handlersGroup = null;
     this._rect = null;
     this._handlers = [];
+     this._rectShape = null;
   },
 
 


### PR DESCRIPTION
Remove handlers       add        
removeHooks: function() {
    this._rectShape = null;    //Add this and you can try it.
}