### PR TITLE
Remove references to image files that don't exist

### DIFF
--- a/example/css/topcoat-desktop-light.css
+++ b/example/css/topcoat-desktop-light.css
@@ -2349,7 +2349,6 @@ input[type="search"]::-webkit-search-cancel-button {
   color: #454545;
   padding: 0 0 0 1.3rem;
   border-radius: 15px;
-  background-image: url("../img/search.svg");
   background-position: 1rem center;
   background-repeat: no-repeat;
   background-size: 12px;
@@ -3305,7 +3304,6 @@ body {
 }
 
 .topcoat-icon--menu-stack {
-  background: url("../img/hamburger_dark.svg") no-repeat;
   background-size: cover;
 }
 


### PR DESCRIPTION
Closes #58 

The reason that I care is because some builders/compressors (like whitenoise) will error out if they encounter references to files that don't exist