### PR TITLE
Prevents handlers from becoming inaccessible when covered by another layer.

### DIFF
--- a/src/Path.Transform.js
+++ b/src/Path.Transform.js
@@ -506,7 +506,7 @@ L.Handler.PathTransform = L.Handler.extend({
 
     // move handlers to the top of all other layers; prevents handlers from
     // being blocked by other layers
-    this._handlersGroup.getLayers().forEach(layer => layer.bringToFront())
+    this._handlersGroup.getLayers().forEach(function(layer) { layer.bringToFront() })
   },
 
   /**

--- a/src/Path.Transform.js
+++ b/src/Path.Transform.js
@@ -506,7 +506,7 @@ L.Handler.PathTransform = L.Handler.extend({
 
     // move handlers to the top of all other layers; prevents handlers from
     // being blocked by other layers
-    this._handlersGroup.getLayers().forEach(function(layer) { layer.bringToFront() })
+    this._handlersGroup.getLayers().forEach(function(layer) { layer.bringToFront(); });
   },
 
   /**

--- a/src/Path.Transform.js
+++ b/src/Path.Transform.js
@@ -503,6 +503,10 @@ L.Handler.PathTransform = L.Handler.extend({
       //add rotation handler
       this._createRotationHandlers();
     }
+
+    // move handlers to the top of all other layers; prevents handlers from
+    // being blocked by other layers
+    this._handlersGroup.getLayers().forEach(layer => layer.bringToFront())
   },
 
   /**


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

I've observed that the handlers can become inaccessible if another layer is rendered over the transformed layer. This patch moves the handlers of the transformed layer to the top of all layers.

Let me know what you think - I'll be happy to answer any question.